### PR TITLE
Remove client edge

### DIFF
--- a/Forms/CompactWindow.cs
+++ b/Forms/CompactWindow.cs
@@ -161,6 +161,7 @@ namespace BorderlessGaming.Forms
                                 & ~(
                                         WindowStyleFlags.ExtendedDlgModalFrame
                                       | WindowStyleFlags.ExtendedComposited
+                                      | WindowStyleFlags.ExtendedClientEdge
                                    ));
 
             ProcessDetails pd = this.ProcessByWindow(targetHandle);
@@ -259,6 +260,7 @@ namespace BorderlessGaming.Forms
                                 |  (
                                         WindowStyleFlags.ExtendedDlgModalFrame
                                       | WindowStyleFlags.ExtendedComposited
+                                      | WindowStyleFlags.ExtendedClientEdge
                                    ));
 
             Native.SetWindowLong(targetHandle, WindowLongIndex.Style, styleNewWindow_standard);


### PR DESCRIPTION
Some games such as The Sims 3 and Euro Truck Simulator 2 are left with a small border while using this tool. This simple fix addresses that issue.