### PR TITLE
Version 7.7

### DIFF
--- a/Forms/MainWindow.Designer.cs
+++ b/Forms/MainWindow.Designer.cs
@@ -87,6 +87,8 @@
             this.toolStripMenuItem11 = new System.Windows.Forms.ToolStripSeparator();
             this.toggleMouseCursorVisibilityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toggleWindowsTaskbarVisibilityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem12 = new System.Windows.Forms.ToolStripSeparator();
+            this.fullApplicationRefreshToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripInfo = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripReportBug = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSupportUs = new System.Windows.Forms.ToolStripMenuItem();
@@ -98,8 +100,6 @@
             this.btnRestoreWindow = new System.Windows.Forms.Button();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.lblUpdateStatus = new System.Windows.Forms.ToolStripStatusLabel();
-            this.fullApplicationRefreshToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem12 = new System.Windows.Forms.ToolStripSeparator();
             this.processContext.SuspendLayout();
             this.mnuFavoritesContext.SuspendLayout();
             this.trayIconContextMenu.SuspendLayout();
@@ -125,6 +125,7 @@
             this.lstProcesses.FormattingEnabled = true;
             this.lstProcesses.Name = "lstProcesses";
             this.lstProcesses.Sorted = true;
+            this.lstProcesses.SelectedIndexChanged += new System.EventHandler(this.lstProcesses_SelectedIndexChanged);
             // 
             // processContext
             // 
@@ -214,6 +215,7 @@
             this.lstFavorites.FormattingEnabled = true;
             this.lstFavorites.Name = "lstFavorites";
             this.lstFavorites.Sorted = true;
+            this.lstFavorites.SelectedIndexChanged += new System.EventHandler(this.lstFavorites_SelectedIndexChanged);
             // 
             // mnuFavoritesContext
             // 
@@ -515,6 +517,17 @@
             resources.ApplyResources(this.toggleWindowsTaskbarVisibilityToolStripMenuItem, "toggleWindowsTaskbarVisibilityToolStripMenuItem");
             this.toggleWindowsTaskbarVisibilityToolStripMenuItem.Click += new System.EventHandler(this.toggleWindowsTaskbarVisibilityToolStripMenuItem_Click);
             // 
+            // toolStripMenuItem12
+            // 
+            this.toolStripMenuItem12.Name = "toolStripMenuItem12";
+            resources.ApplyResources(this.toolStripMenuItem12, "toolStripMenuItem12");
+            // 
+            // fullApplicationRefreshToolStripMenuItem
+            // 
+            this.fullApplicationRefreshToolStripMenuItem.Name = "fullApplicationRefreshToolStripMenuItem";
+            resources.ApplyResources(this.fullApplicationRefreshToolStripMenuItem, "fullApplicationRefreshToolStripMenuItem");
+            this.fullApplicationRefreshToolStripMenuItem.Click += new System.EventHandler(this.fullApplicationRefreshToolStripMenuItem_Click);
+            // 
             // toolStripInfo
             // 
             this.toolStripInfo.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -591,17 +604,6 @@
             // 
             this.lblUpdateStatus.Name = "lblUpdateStatus";
             resources.ApplyResources(this.lblUpdateStatus, "lblUpdateStatus");
-            // 
-            // fullApplicationRefreshToolStripMenuItem
-            // 
-            this.fullApplicationRefreshToolStripMenuItem.Name = "fullApplicationRefreshToolStripMenuItem";
-            resources.ApplyResources(this.fullApplicationRefreshToolStripMenuItem, "fullApplicationRefreshToolStripMenuItem");
-            this.fullApplicationRefreshToolStripMenuItem.Click += new System.EventHandler(this.fullApplicationRefreshToolStripMenuItem_Click);
-            // 
-            // toolStripMenuItem12
-            // 
-            this.toolStripMenuItem12.Name = "toolStripMenuItem12";
-            resources.ApplyResources(this.toolStripMenuItem12, "toolStripMenuItem12");
             // 
             // MainWindow
             // 

--- a/Forms/MainWindow.resx
+++ b/Forms/MainWindow.resx
@@ -143,54 +143,6 @@
   <metadata name="processContext.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>394, 23</value>
   </metadata>
-  <data name="byTheWindowTitleTextToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="byTheWindowTitleTextToolStripMenuItem.Text" xml:space="preserve">
-    <value>... by the window title text</value>
-  </data>
-  <data name="byTheProcessBinaryNameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="byTheProcessBinaryNameToolStripMenuItem.Text" xml:space="preserve">
-    <value>... by the process binary name</value>
-  </data>
-  <data name="contextAddToFavs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 22</value>
-  </data>
-  <data name="contextAddToFavs.Text" xml:space="preserve">
-    <value>Add to Favorites...</value>
-  </data>
-  <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>183, 6</value>
-  </data>
-  <data name="contextBorderless.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 22</value>
-  </data>
-  <data name="contextBorderless.Text" xml:space="preserve">
-    <value>Make Borderless</value>
-  </data>
-  <data name="contextBorderlessOn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 22</value>
-  </data>
-  <data name="contextBorderlessOn.Text" xml:space="preserve">
-    <value>Make Borderless on...</value>
-  </data>
-  <data name="setWindowTitleToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 22</value>
-  </data>
-  <data name="setWindowTitleToolStripMenuItem.Text" xml:space="preserve">
-    <value>Set Window Title</value>
-  </data>
-  <data name="toolStripMenuItem8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>183, 6</value>
-  </data>
-  <data name="hideThisProcessToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 22</value>
-  </data>
-  <data name="hideThisProcessToolStripMenuItem.Text" xml:space="preserve">
-    <value>Hide This Process</value>
-  </data>
   <data name="processContext.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 126</value>
   </data>
@@ -225,6 +177,54 @@
   <data name="&gt;&gt;lstProcesses.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="contextAddToFavs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 22</value>
+  </data>
+  <data name="contextAddToFavs.Text" xml:space="preserve">
+    <value>Add to Favorites...</value>
+  </data>
+  <data name="byTheWindowTitleTextToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="byTheWindowTitleTextToolStripMenuItem.Text" xml:space="preserve">
+    <value>... by the window title text</value>
+  </data>
+  <data name="byTheProcessBinaryNameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="byTheProcessBinaryNameToolStripMenuItem.Text" xml:space="preserve">
+    <value>... by the process binary name</value>
+  </data>
+  <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 6</value>
+  </data>
+  <data name="contextBorderless.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 22</value>
+  </data>
+  <data name="contextBorderless.Text" xml:space="preserve">
+    <value>Make Borderless</value>
+  </data>
+  <data name="contextBorderlessOn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 22</value>
+  </data>
+  <data name="contextBorderlessOn.Text" xml:space="preserve">
+    <value>Make Borderless on...</value>
+  </data>
+  <data name="setWindowTitleToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 22</value>
+  </data>
+  <data name="setWindowTitleToolStripMenuItem.Text" xml:space="preserve">
+    <value>Set Window Title</value>
+  </data>
+  <data name="toolStripMenuItem8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 6</value>
+  </data>
+  <data name="hideThisProcessToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 22</value>
+  </data>
+  <data name="hideThisProcessToolStripMenuItem.Text" xml:space="preserve">
+    <value>Hide This Process</value>
+  </data>
   <metadata name="tmrWork.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>281, 19</value>
   </metadata>
@@ -258,6 +258,39 @@
   <metadata name="mnuFavoritesContext.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>745, 17</value>
   </metadata>
+  <data name="mnuFavoritesContext.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 242</value>
+  </data>
+  <data name="&gt;&gt;mnuFavoritesContext.Name" xml:space="preserve">
+    <value>mnuFavoritesContext</value>
+  </data>
+  <data name="&gt;&gt;mnuFavoritesContext.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lstFavorites.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="lstFavorites.Location" type="System.Drawing.Point, System.Drawing">
+    <value>259, 21</value>
+  </data>
+  <data name="lstFavorites.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 216</value>
+  </data>
+  <data name="lstFavorites.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lstFavorites.Name" xml:space="preserve">
+    <value>lstFavorites</value>
+  </data>
+  <data name="&gt;&gt;lstFavorites.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lstFavorites.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;lstFavorites.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="fullScreenToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>198, 22</value>
   </data>
@@ -326,39 +359,6 @@
   </data>
   <data name="contextRemoveFromFavs.Text" xml:space="preserve">
     <value>Remove From Favorites</value>
-  </data>
-  <data name="mnuFavoritesContext.Size" type="System.Drawing.Size, System.Drawing">
-    <value>199, 242</value>
-  </data>
-  <data name="&gt;&gt;mnuFavoritesContext.Name" xml:space="preserve">
-    <value>mnuFavoritesContext</value>
-  </data>
-  <data name="&gt;&gt;mnuFavoritesContext.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lstFavorites.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="lstFavorites.Location" type="System.Drawing.Point, System.Drawing">
-    <value>259, 21</value>
-  </data>
-  <data name="lstFavorites.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 216</value>
-  </data>
-  <data name="lstFavorites.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lstFavorites.Name" xml:space="preserve">
-    <value>lstFavorites</value>
-  </data>
-  <data name="&gt;&gt;lstFavorites.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lstFavorites.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;lstFavorites.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="btnRemoveFavorite.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 45</value>
@@ -447,21 +447,6 @@
   <metadata name="trayIconContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>16, 19</value>
   </metadata>
-  <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 22</value>
-  </data>
-  <data name="openToolStripMenuItem.Text" xml:space="preserve">
-    <value>Show</value>
-  </data>
-  <data name="toolStripMenuItem7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>191, 6</value>
-  </data>
-  <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 22</value>
-  </data>
-  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
-    <value>Exit Borderless Gaming</value>
-  </data>
   <data name="trayIconContextMenu.Size" type="System.Drawing.Size, System.Drawing">
     <value>195, 54</value>
   </data>
@@ -499,9 +484,57 @@
   <data name="trayIcon.Visible" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="openToolStripMenuItem.Text" xml:space="preserve">
+    <value>Show</value>
+  </data>
+  <data name="toolStripMenuItem7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>191, 6</value>
+  </data>
+  <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>Exit Borderless Gaming</value>
+  </data>
   <metadata name="mnuMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>520, 17</value>
   </metadata>
+  <data name="mnuMain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="mnuMain.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 31</value>
+  </data>
+  <data name="mnuMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>471, 31</value>
+  </data>
+  <data name="mnuMain.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="mnuMain.Text" xml:space="preserve">
+    <value>mnuMain</value>
+  </data>
+  <data name="&gt;&gt;mnuMain.Name" xml:space="preserve">
+    <value>mnuMain</value>
+  </data>
+  <data name="&gt;&gt;mnuMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;mnuMain.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mnuMain.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="toolStripOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 27</value>
+  </data>
+  <data name="toolStripOptions.Text" xml:space="preserve">
+    <value>&amp;Options</value>
+  </data>
   <data name="toolStripRunOnStartup.Size" type="System.Drawing.Size, System.Drawing">
     <value>314, 22</value>
   </data>
@@ -565,11 +598,11 @@
   <data name="resToolStripMenuItem.Text" xml:space="preserve">
     <value>Restore All Hidden Applications</value>
   </data>
-  <data name="toolStripOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 27</value>
+  <data name="toolsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 27</value>
   </data>
-  <data name="toolStripOptions.Text" xml:space="preserve">
-    <value>&amp;Options</value>
+  <data name="toolsToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Tools</value>
   </data>
   <data name="pauseAutomaticProcessingToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>254, 22</value>
@@ -607,11 +640,11 @@
   <data name="fullApplicationRefreshToolStripMenuItem.Text" xml:space="preserve">
     <value>Full Application Refresh</value>
   </data>
-  <data name="toolsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 27</value>
+  <data name="toolStripInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 27</value>
   </data>
-  <data name="toolsToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Tools</value>
+  <data name="toolStripInfo.Text" xml:space="preserve">
+    <value>&amp;Help</value>
   </data>
   <data name="toolStripReportBug.Size" type="System.Drawing.Size, System.Drawing">
     <value>142, 22</value>
@@ -634,39 +667,6 @@
   <data name="toolStripAbout.Text" xml:space="preserve">
     <value>About...</value>
   </data>
-  <data name="toolStripInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 27</value>
-  </data>
-  <data name="toolStripInfo.Text" xml:space="preserve">
-    <value>&amp;Help</value>
-  </data>
-  <data name="mnuMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="mnuMain.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 31</value>
-  </data>
-  <data name="mnuMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>471, 31</value>
-  </data>
-  <data name="mnuMain.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="mnuMain.Text" xml:space="preserve">
-    <value>mnuMain</value>
-  </data>
-  <data name="&gt;&gt;mnuMain.Name" xml:space="preserve">
-    <value>mnuMain</value>
-  </data>
-  <data name="&gt;&gt;mnuMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mnuMain.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mnuMain.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <metadata name="wrkBackgroundWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>628, 17</value>
   </metadata>
@@ -678,18 +678,6 @@
   </data>
   <data name="flowLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="btnRestoreWindow.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnRestoreWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 129</value>
-  </data>
-  <data name="btnRestoreWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 36</value>
-  </data>
-  <data name="btnRestoreWindow.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
   </data>
   <data name="&gt;&gt;btnRestoreWindow.Name" xml:space="preserve">
     <value>btnRestoreWindow</value>
@@ -754,15 +742,33 @@
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="processLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="favoritesLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lstProcesses" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lstFavorites" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="flowLayoutPanel1" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Absolute,42,Percent,50" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
+  <data name="btnRestoreWindow.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnRestoreWindow.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 129</value>
+  </data>
+  <data name="btnRestoreWindow.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 36</value>
+  </data>
+  <data name="btnRestoreWindow.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;btnRestoreWindow.Name" xml:space="preserve">
+    <value>btnRestoreWindow</value>
+  </data>
+  <data name="&gt;&gt;btnRestoreWindow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRestoreWindow.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;btnRestoreWindow.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>885, 17</value>
   </metadata>
-  <data name="lblUpdateStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 17</value>
-  </data>
-  <data name="lblUpdateStatus.Text" xml:space="preserve">
-    <value>Loading...</value>
-  </data>
   <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 274</value>
   </data>
@@ -786,6 +792,12 @@
   </data>
   <data name="&gt;&gt;statusStrip1.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="lblUpdateStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 17</value>
+  </data>
+  <data name="lblUpdateStatus.Text" xml:space="preserve">
+    <value>Loading...</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -1103,6 +1115,18 @@
   <data name="&gt;&gt;toggleWindowsTaskbarVisibilityToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;toolStripMenuItem12.Name" xml:space="preserve">
+    <value>toolStripMenuItem12</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem12.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fullApplicationRefreshToolStripMenuItem.Name" xml:space="preserve">
+    <value>fullApplicationRefreshToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;fullApplicationRefreshToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toolStripInfo.Name" xml:space="preserve">
     <value>toolStripInfo</value>
   </data>
@@ -1144,18 +1168,6 @@
   </data>
   <data name="&gt;&gt;lblUpdateStatus.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fullApplicationRefreshToolStripMenuItem.Name" xml:space="preserve">
-    <value>fullApplicationRefreshToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;fullApplicationRefreshToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem12.Name" xml:space="preserve">
-    <value>toolStripMenuItem12</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MainWindow</value>

--- a/Installer/BorderlessGaming.iss
+++ b/Installer/BorderlessGaming.iss
@@ -18,11 +18,11 @@ DisableProgramGroupPage=yes
 DirExistsWarning=no
 
 ; Shown as installed version (Programs & Features) as well as product version ('Details' tab when right-clicking setup program and choosing 'Properties')
-AppVersion=7.6
+AppVersion=7.7
 ; Stored in the version info for the setup program itself ('Details' tab when right-clicking setup program and choosing 'Properties')
-VersionInfoVersion=7.6.915.629
+VersionInfoVersion=7.7.1015.1177
 ; Other version info
-OutputBaseFilename=BorderlessGaming_7.6__setup
+OutputBaseFilename=BorderlessGaming_7.7__setup
 
 
 ; Shown in the setup program during install only
@@ -36,7 +36,7 @@ AppSupportURL=https://github.com/Codeusa/Borderless-Gaming/issues
 AppUpdatesURL=https://github.com/Codeusa/Borderless-Gaming/releases/latest
 UninstallDisplayName=Borderless Gaming
 ; 691 KB as initial install
-UninstallDisplaySize=707733
+UninstallDisplaySize=720021
 UninstallDisplayIcon={app}\BorderlessGaming.exe
 
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("7.6.915.629")]
-[assembly: AssemblyFileVersion("7.6.915.629")]
+[assembly: AssemblyVersion("7.7.1015.1177")]
+[assembly: AssemblyFileVersion("7.7.1015.1177")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/Utilities/Tools.cs
+++ b/Utilities/Tools.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Net.NetworkInformation;
 using System.Reflection;
+using System.Threading;
 using System.Windows.Forms;
 using System.Xml;
 using BorderlessGaming.Properties;
@@ -182,6 +183,121 @@ namespace BorderlessGaming.Utilities
 
                 return new List<string>();
             }
+        }
+
+
+        public static void StartMethodMultithreadedAndWait(Action target)
+        {
+            StartMethodMultithreadedAndWait(target, 0);
+        }
+
+        public static void StartMethodMultithreadedAndWait(Action target, int iHowLongToWait)
+        {
+            try
+            {
+                ThreadStart tsGenericMethod = new ThreadStart(() => { try { target(); } catch { } });
+                Thread trdGenericThread = new Thread(tsGenericMethod);
+                trdGenericThread.IsBackground = true;
+                trdGenericThread.Start();
+
+                DateTime dtStartTime = DateTime.Now;
+
+                for (; ; )
+                {
+                    if (iHowLongToWait > 0)
+                    {
+                        if ((DateTime.Now - dtStartTime).TotalSeconds > iHowLongToWait)
+                        {
+                            try { trdGenericThread.Abort(); } catch { }
+                            break;
+                        }
+                    }
+
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.Stopped) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.StopRequested) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.Aborted) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.AbortRequested) break;
+
+                    Thread.Sleep(15);
+                    Forms.MainWindow.DoEvents();
+                }
+            }
+            catch { }
+        }
+
+        public static void StartMethodMultithreadedAndWait(Action target, double dHowLongToWait)
+        {
+            try
+            {
+                ThreadStart tsGenericMethod = new ThreadStart(() => { try { target(); } catch { } });
+                Thread trdGenericThread = new Thread(tsGenericMethod);
+                trdGenericThread.IsBackground = true;
+                trdGenericThread.Start();
+
+                DateTime dtStartTime = DateTime.Now;
+
+                for (; ; )
+                {
+                    if (dHowLongToWait > 0.0)
+                    {
+                        if ((DateTime.Now - dtStartTime).TotalMilliseconds > dHowLongToWait)
+                        {
+                            try { trdGenericThread.Abort(); } catch { }
+                            break;
+                        }
+                    }
+
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.Stopped) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.StopRequested) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.Aborted) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.AbortRequested) break;
+
+                    Thread.Sleep(15);
+                    Forms.MainWindow.DoEvents();
+                }
+            }
+            catch { }
+        }
+
+        public static void StartMethodAndWait(Action target, double dHowLongToWait)
+        {
+            try
+            {
+                ThreadStart tsGenericMethod = new ThreadStart(() => { try { target(); } catch { } });
+                Thread trdGenericThread = new Thread(tsGenericMethod);
+                trdGenericThread.IsBackground = false;
+                trdGenericThread.Start();
+
+                DateTime dtStartTime = DateTime.Now;
+
+                for (; ; )
+                {
+                    if (dHowLongToWait > 0.0)
+                    {
+                        if ((DateTime.Now - dtStartTime).TotalMilliseconds > dHowLongToWait)
+                        {
+                            try { trdGenericThread.Abort(); } catch { }
+                            break;
+                        }
+                    }
+
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.Stopped) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.StopRequested) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.Aborted) break;
+                    if (trdGenericThread.ThreadState == System.Threading.ThreadState.AbortRequested) break;
+
+                    Thread.Sleep(15);
+                }
+            }
+            catch { }
+        }
+
+        public static void StartMethodMultithreaded(Action target)
+        {
+            ThreadStart tsGenericMethod = new ThreadStart(() => { try { target(); } catch { } });
+            Thread trdGenericThread = new Thread(tsGenericMethod);
+            trdGenericThread.IsBackground = true;
+            trdGenericThread.Start();
         }
     }
 }

--- a/WindowsApi/Enumerations.cs
+++ b/WindowsApi/Enumerations.cs
@@ -1545,4 +1545,20 @@ namespace BorderlessGaming.WindowsAPI
         /// </summary>
         OCR_WAIT = 32514
     }
+
+    public enum GetAncestorFlags
+    {
+        /// <summary>
+        /// Retrieves the parent window. This does not include the owner, as it does with the GetParent function. 
+        /// </summary>
+        GetParent = 1,
+        /// <summary>
+        /// Retrieves the root window by walking the chain of parent windows.
+        /// </summary>
+        GetRoot = 2,
+        /// <summary>
+        /// Retrieves the owned root window by walking the chain of parent and owner windows returned by GetParent. 
+        /// </summary>
+        GetRootOwner = 3
+    }
 }

--- a/version.xml
+++ b/version.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <borderlessgaming>
-	<version>7.6</version>
+	<version>7.7</version>
 	<url>https://github.com/Codeusa/Borderless-Gaming/releases/latest</url>
 </borderlessgaming>


### PR DESCRIPTION
Changes:
* Improved main window handle detection by avoiding
Process.MainWindowHandle and actually using native window enumeration
with some filtering to avoid dummy windows.  This adds support for more
game titles that previously weren't working.
* Added detection of access-denied errors from elevated processes and
automatically marking not to check them throughout the application
lifetime (improves performance).
* Made the buttons automatically gray out if no applicable selection is
made in the Applications or Favorites lists.
* Updated GetWindowLong to GetWindowLongPtr (SetWindowLong was already
updated in a previous version of Borderless Gaming) for better
compatibility with windows owned by 64-bit processes.
* Added basic threading tools and made things more thread-safe.
* Added future support for finding windows and processes from a specific
screen position.