### PR TITLE
Version 7.8

### DIFF
--- a/BorderlessGaming.csproj
+++ b/BorderlessGaming.csproj
@@ -55,7 +55,7 @@
     <ApplicationIcon>BorderlessGaming.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationManifest>app.Launch as User.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>BorderlessGaming.Program</StartupObject>
@@ -147,7 +147,8 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.de.resx" />
-    <None Include="app.manifest" />
+    <None Include="app.Launch as User.manifest" />
+    <None Include="app.Launch as Elevated.manifest" />
     <None Include="data\blank.cur" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/Installer/BorderlessGaming.iss
+++ b/Installer/BorderlessGaming.iss
@@ -18,11 +18,11 @@ DisableProgramGroupPage=yes
 DirExistsWarning=no
 
 ; Shown as installed version (Programs & Features) as well as product version ('Details' tab when right-clicking setup program and choosing 'Properties')
-AppVersion=7.7
+AppVersion=7.8
 ; Stored in the version info for the setup program itself ('Details' tab when right-clicking setup program and choosing 'Properties')
-VersionInfoVersion=7.7.1015.1177
+VersionInfoVersion=7.8.1415.1112
 ; Other version info
-OutputBaseFilename=BorderlessGaming_7.7__setup
+OutputBaseFilename=BorderlessGaming_7.8__setup
 
 
 ; Shown in the setup program during install only

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("7.7.1015.1177")]
-[assembly: AssemblyFileVersion("7.7.1015.1177")]
+[assembly: AssemblyVersion("7.8.1415.1112")]
+[assembly: AssemblyFileVersion("7.8.1415.1112")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/app.Launch as Elevated.manifest
+++ b/app.Launch as Elevated.manifest
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+            If you want to change the Windows User Account Control level replace the 
+            requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel node will disable file and registry virtualization.
+            If you want to utilize File and Registry Virtualization for backward 
+            compatibility then delete the requestedExecutionLevel node.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of all Windows versions that this application is designed to work with. 
+      Windows will automatically select the most compatible environment.-->
+
+      <!-- If your application is designed to work with Windows Vista, uncomment the following supportedOS node-->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"></supportedOS>-->
+
+      <!-- If your application is designed to work with Windows 7, uncomment the following supportedOS node-->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>-->
+
+      <!-- If your application is designed to work with Windows 8, uncomment the following supportedOS node-->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"></supportedOS>-->
+
+      <!-- If your application is designed to work with Windows 8.1, uncomment the following supportedOS node-->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>-->
+
+    </application>
+  </compatibility>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!-- <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>-->
+
+</asmv1:assembly>

--- a/app.Launch as User.manifest
+++ b/app.Launch as User.manifest
@@ -16,7 +16,7 @@
             If you want to utilize File and Registry Virtualization for backward 
             compatibility then delete the requestedExecutionLevel node.
         -->
-        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/version.xml
+++ b/version.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <borderlessgaming>
-	<version>7.7</version>
+	<version>7.8</version>
 	<url>https://github.com/Codeusa/Borderless-Gaming/releases/latest</url>
 </borderlessgaming>


### PR DESCRIPTION
* Fixes issue #99: using close-to-tray would prevent the 'exit' option from the system tray context menu from working.
* Multiple builds now, one for elevated (run-as-administrator) and one that runs normally.  Addresses issue #94 and issue #100.

Builds available here:
https://github.com/psouza4/Borderless-Gaming/releases/tag/7.8

Note: two builds, one for each admin and non-admin.