### PR TITLE
Show "child" windows of cmd processes

### DIFF
--- a/BorderlessGaming.cs
+++ b/BorderlessGaming.cs
@@ -157,7 +157,8 @@ namespace BorderlessGaming
                     {
                         if (_hiddenProcesses.IsHidden(pd.Proc.ProcessName))
                             return;
-                        if (!_processDetails.Select(p => p.Proc.Id).Contains(pd.Proc.Id))
+                        if (!_processDetails.Select(p => p.Proc.Id).Contains(pd.Proc.Id) ||
+                            !_processDetails.Select(p => p.WindowTitle).Contains(pd.WindowTitle))
                             _processDetails.Add(pd);
                     }, _processDetails.WindowPtrSet);
                 }


### PR DESCRIPTION
I have a process that spawns a cmd window in addition to a (already borderless but the wrong size) game window. Current version of Borderless Gaming doesn't see it, only sees the cmd window.

By relaxing the dupe check so that same-process-different-title windows also get included into the list, the window is seen.

Should also fix #200 