### PR TITLE
for portability and improved OOB experience use exe path as data path

### DIFF
--- a/BorderlessGaming.Logic/System/AppEnvironment.cs
+++ b/BorderlessGaming.Logic/System/AppEnvironment.cs
@@ -20,54 +20,10 @@ namespace BorderlessGaming.Logic.System
         {
             get
             {
-                var versionInfo = FileVersionInfo.GetVersionInfo(Path);
-                var userAppData = GetUserAppDataPath();
-                try
-                {
-                    // No version!
-                    return Environment.GetEnvironmentVariable("AppData").Trim() + "\\" + versionInfo.CompanyName +
-                           "\\" + versionInfo.ProductName;
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    // Version, but chopped out
-                    return userAppData.Substring(0, userAppData.LastIndexOf("\\"));
-                }
-                catch
-                {
-                    try
-                    {
-                        // App launch folder
-                        var directoryInfo = new FileInfo(Path).Directory;
-                        var dir = directoryInfo.ToString();
-                        return Path.Substring(0, dir.LastIndexOf("\\", StringComparison.Ordinal));
-                    }
-                    catch
-                    {
-                        try
-                        {
-                            // Current working folder
-                            return Environment.CurrentDirectory;
-                        }
-                        catch
-                        {
-                            try
-                            {
-                                // Desktop
-                                return Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
-                            }
-                            catch
-                            {
-                                // Also current working folder
-                                return ".";
-                            }
-                        }
-                    }
-                }
+                var exeLoc = Assembly.GetExecutingAssembly().Location;
+                var exeLocFull = global::System.IO.Path.GetFullPath(exeLoc);
+                var exeFolderPath = global::System.IO.Path.GetDirectoryName(exeLocFull);
+                return exeFolderPath;
             }
         }
 

--- a/BorderlessGaming/BorderlessGaming.csproj
+++ b/BorderlessGaming/BorderlessGaming.csproj
@@ -238,9 +238,11 @@
       $(PostBuildEventDependsOn);
       PostBuildMacros;
     </PostBuildEventDependsOn>
-    <PostBuildEvent>call signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /as /sha1 3BD5BE571287FE2052F137C44198AE7BAB38B037 "$(ProjectDir)$(OutDir)$(TargetFileName)"
-call iscc /Qp "$(SolutionDir)\Installers\BorderlessGaming_Standalone_Admin.iss"
-call signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /as /sha1 3BD5BE571287FE2052F137C44198AE7BAB38B037 "$(SolutionDir)Installers\BorderlessGaming@(VersionNumber)_admin_setup.exe"</PostBuildEvent>
+    <PostBuildEvent>Xcopy /E /H /C /I "$(SolutionDir)Languages" "$(ProjectDir)$(OutDir)Languages"
+
+rem call "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool" sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /as /sha1 3BD5BE571287FE2052F137C44198AE7BAB38B037 "$(ProjectDir)$(OutDir)$(TargetFileName)"
+rem call iscc /Qp "$(SolutionDir)\Installers\BorderlessGaming_Standalone_Admin.iss"
+rem call "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool" sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /as /sha1 3BD5BE571287FE2052F137C44198AE7BAB38B037 "$(SolutionDir)Installers\BorderlessGaming@(VersionNumber)_admin_setup.exe"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>copy $(SolutionDir)SteamLibs\* $(ProjectDir)$(OutDir)</PreBuildEvent>


### PR DESCRIPTION
also, by default don't sign, so that without access to private developer keys it can still be built